### PR TITLE
Fix STACK API CORS issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: "3.0"
 services:
   web:
     build:
       context: ./web
+    image: idems/stack-api-example:latest
     ports:
       - "8080:80"
     volumes:
@@ -21,7 +21,9 @@ services:
       GOEMAXIMA_QUEUE_LEN: 32
     read_only: true
   stack:
-    image: stackmaths/stackapi:2024072400-latest
+    image: idems/stackapi:latest
+    build:
+      context: ./stackapi
     restart: unless-stopped
     ports:
-      - '3080:80'
+      - "3080:80"

--- a/stackapi/000-default.conf
+++ b/stackapi/000-default.conf
@@ -1,0 +1,21 @@
+<VirtualHost *:80>
+    DocumentRoot ${APACHE_DOCUMENT_ROOT}
+
+    ErrorLog /dev/stderr
+    TransferLog /dev/stdout
+
+    Alias "/plots" "/var/data/api/stack/plots"
+    <Directory "/var/data/api/stack/plots">
+        Require all granted
+    </Directory>
+
+    Header onsuccess unset Access-Control-Allow-Origin
+    Header always set Access-Control-Allow-Origin "*"
+    Header always set Access-Control-Allow-Headers "*"
+    Header always set Access-Control-Allow-Methods "GET,POST"
+    Header always set Access-Control-Max-Age "600"
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_METHOD} OPTIONS
+    RewriteRule ^(.*)$ $1 [R=200,L]
+</VirtualHost>

--- a/stackapi/Dockerfile
+++ b/stackapi/Dockerfile
@@ -1,0 +1,3 @@
+FROM stackmaths/stackapi:2024072400-latest
+RUN a2enmod headers
+COPY 000-default.conf /etc/apache2/sites-available/000-default.conf

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -2,30 +2,6 @@ server {
     listen 80;
     server_name localhost;
 
-    location /plots {
-        proxy_pass http://stack:80;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /stack-api/ {
-        proxy_pass http://stack:80/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    location /cors.php {
-        proxy_pass http://stack:80;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     location / {
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
Allows STACK API to be deployed separately from example site. Overrides stackapi container image to add appropriate CORS headers. Rewrites references to '/cors.php' to point to actual location of API server.