### PR TITLE
Log POST request body with dumpost

### DIFF
--- a/stackapi/000-default.conf
+++ b/stackapi/000-default.conf
@@ -5,6 +5,7 @@
     TransferLog /dev/stdout
     LogLevel ${STACK_LOG_LEVEL}
 
+    DumpPostLogFile ${DUMP_POST_LOG_FILE}
     DumpPostMaxSize ${DUMP_POST_MAX_SIZE}
 
     Alias "/plots" "/var/data/api/stack/plots"

--- a/stackapi/000-default.conf
+++ b/stackapi/000-default.conf
@@ -3,6 +3,9 @@
 
     ErrorLog /dev/stderr
     TransferLog /dev/stdout
+    LogLevel ${STACK_LOG_LEVEL}
+
+    DumpPostMaxSize ${DUMP_POST_MAX_SIZE}
 
     Alias "/plots" "/var/data/api/stack/plots"
     <Directory "/var/data/api/stack/plots">

--- a/stackapi/Dockerfile
+++ b/stackapi/Dockerfile
@@ -6,10 +6,12 @@ RUN git clone --depth 1 https://github.com/danghvu/mod_dumpost.git
 RUN cd mod_dumpost && make && apxs -i -A -n dumpost mod_dumpost.la
 
 FROM stackmaths/stackapi:2024072400-latest
-ENV DUMP_POST_MAX_SIZE=256000 \
+ENV DUMP_POST_LOG_FILE=/var/log/dumpost.log \
+    DUMP_POST_MAX_SIZE=256000 \
     STACK_LOG_LEVEL=info
 COPY --from=builder /usr/lib/apache2/modules/mod_dumpost.so /usr/lib/apache2/modules/
 COPY --from=builder /etc/apache2/mods-available/dumpost.load /etc/apache2/mods-available/
 RUN a2enmod dumpost
 RUN a2enmod headers
+RUN touch ${DUMP_POST_LOG_FILE} && chown www-data ${DUMP_POST_LOG_FILE}
 COPY 000-default.conf /etc/apache2/sites-available/000-default.conf

--- a/stackapi/Dockerfile
+++ b/stackapi/Dockerfile
@@ -1,3 +1,15 @@
+FROM stackmaths/stackapi:2024072400-latest AS builder
+WORKDIR /opt/idems
+RUN apt update \
+ && apt install --yes --no-install-recommends apache2-dev git
+RUN git clone --depth 1 https://github.com/danghvu/mod_dumpost.git
+RUN cd mod_dumpost && make && apxs -i -A -n dumpost mod_dumpost.la
+
 FROM stackmaths/stackapi:2024072400-latest
+ENV DUMP_POST_MAX_SIZE=256000 \
+    STACK_LOG_LEVEL=info
+COPY --from=builder /usr/lib/apache2/modules/mod_dumpost.so /usr/lib/apache2/modules/
+COPY --from=builder /etc/apache2/mods-available/dumpost.load /etc/apache2/mods-available/
+RUN a2enmod dumpost
 RUN a2enmod headers
 COPY 000-default.conf /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
A quick way to record information that would give us insight into which questions have been attempted, how often, and with which answers.

POST request payloads would be logged to stderr via the [dumpost module](https://github.com/danghvu/mod_dumpost/tree/master). Two environment variables can be used for basic control of the module:

- `STACK_LOG_LEVEL`: sets `LogLevel` in Apache for the STACK virtualhost; any valid Apache log level is accepted; to enable logging of POST request payloads, this must be set to at least as verbose as `info`; default is `info`.
- `DUMP_POST_MAX_SIZE`: sets a limit for the maximum amount of POST payload data that will be logged; default is `256000`.

Google Cloud Platform's Cloud Logging product will accept log entries as large as 256 KB.